### PR TITLE
`[[deprecated]]` usage disabled for C++11

### DIFF
--- a/cxx_function.hpp
+++ b/cxx_function.hpp
@@ -36,21 +36,19 @@ namespace impl {
 
 #define UGLY( NAME ) CXX_FUNCTION_ ## NAME
 
-#if __GNUC__ && ! __clang__ && __GNUC__ < 5
-#   define is_trivially_move_constructible has_trivial_copy_constructor
-#   define is_trivially_copy_constructible has_trivial_copy_constructor
-
-#   define deprecated(MSG) __attribute__((deprecated (MSG)))
-
-#   define OLD_GCC_FIX(...) __VA_ARGS__
-#   define OLD_GCC_SKIP(...)
-#else
 #if __cplusplus < 201402L
 #   define deprecated(MSG) __attribute__((deprecated (MSG)))
 #else
 #   define deprecated(MSG) [[deprecated (MSG)]]
 #endif
 
+#if __GNUC__ && ! __clang__ && __GNUC__ < 5
+#   define is_trivially_move_constructible has_trivial_copy_constructor
+#   define is_trivially_copy_constructible has_trivial_copy_constructor
+
+#   define OLD_GCC_FIX(...) __VA_ARGS__
+#   define OLD_GCC_SKIP(...)
+#else
 #   define OLD_GCC_FIX(...)
 #   define OLD_GCC_SKIP(...) __VA_ARGS__
 #endif

--- a/cxx_function.hpp
+++ b/cxx_function.hpp
@@ -36,7 +36,7 @@ namespace impl {
 
 #define UGLY( NAME ) CXX_FUNCTION_ ## NAME
 
-#if __cplusplus < 201402L
+#if __GNUC__ && ! __clang__ && __cplusplus < 201402L
 #   define deprecated(MSG) __attribute__((deprecated (MSG)))
 #else
 #   define deprecated(MSG) [[deprecated (MSG)]]

--- a/cxx_function.hpp
+++ b/cxx_function.hpp
@@ -45,7 +45,11 @@ namespace impl {
 #   define OLD_GCC_FIX(...) __VA_ARGS__
 #   define OLD_GCC_SKIP(...)
 #else
+#if __cplusplus < 201402L
+#   define deprecated(MSG) __attribute__((deprecated (MSG)))
+#else
 #   define deprecated(MSG) [[deprecated (MSG)]]
+#endif
 
 #   define OLD_GCC_FIX(...)
 #   define OLD_GCC_SKIP(...) __VA_ARGS__

--- a/cxx_function.hpp
+++ b/cxx_function.hpp
@@ -36,7 +36,7 @@ namespace impl {
 
 #define UGLY( NAME ) CXX_FUNCTION_ ## NAME
 
-#if __GNUC__ && ! __clang__ && __cplusplus < 201402L
+#if __cplusplus < 201402L && ! _MSC_VER
 #   define deprecated(MSG) __attribute__((deprecated (MSG)))
 #else
 #   define deprecated(MSG) [[deprecated (MSG)]]


### PR DESCRIPTION
`[[deprecated]]` attribute was introduced in C++14. This library claims to be compatible with C++11. This is why it was replaced with `__attribute__` usage.